### PR TITLE
Fix invalid ifequal template tag

### DIFF
--- a/templates/inventory/supplier_products.html
+++ b/templates/inventory/supplier_products.html
@@ -128,8 +128,7 @@
                             <select name="category" class="form-select">
                                 <option value="">All Categories</option>
                                 {% for value, label in categories %}
-                                <option value="{{ value }}" {% ifequal value selected_category %}selected{% endifequal
-                                    %}>
+                                <option value="{{ value }}" {% if value == selected_category %}selected{% endif %}>
                                     {{ label }}
                                 </option>
                                 {% endfor %}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Replace deprecated `ifequal` tag with `if` to fix `TemplateSyntaxError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-dbdf64ca-1338-4638-82c2-73cbdffa06ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dbdf64ca-1338-4638-82c2-73cbdffa06ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>